### PR TITLE
Create initial version of free5gc-cp kpt package

### DIFF
--- a/free5gc-cp/Kptfile
+++ b/free5gc-cp/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: free5gc-cp
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: this package represents free5gc NFs, which are required to perform E2E conn testing
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configPath: package-context.yaml

--- a/free5gc-cp/README.md
+++ b/free5gc-cp/README.md
@@ -1,0 +1,24 @@
+# free5gc-cp
+
+## Description
+sample description
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] free5gc-cp`
+
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree free5gc-cp`
+
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init free5gc-cp
+kpt live apply free5gc-cp --reconcile-timeout=2m --output=table
+```
+
+Details: https://kpt.dev/reference/cli/live/

--- a/free5gc-cp/amf/amf-configmap.yaml
+++ b/free5gc-cp/amf/amf-configmap.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amf-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    
+data:
+  amfcfg.yaml: |
+    info:
+      version: 1.0.3
+      description: AMF initial local configuration
+
+    configuration:
+      serviceNameList:
+        - namf-comm
+        - namf-evts
+        - namf-mt
+        - namf-loc
+        - namf-oam
+
+      ngapIpList:
+        - 10.100.50.249
+      sbi:
+        scheme: http
+        registerIPv4: amf-namf  # IP used to register to NRF
+        bindingIPv4: 0.0.0.0    # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/amf.key
+          pem: config/TLS/amf.pem
+      
+      nrfUri: http://nrf-nnrf:8000
+      amfName: AMF
+      serviceNameList:
+        - namf-comm
+        - namf-evts
+        - namf-mt
+        - namf-loc
+        - namf-oam
+      servedGuamiList:
+        - plmnId:
+            mcc: 208
+            mnc: 93
+          amfId: cafe00
+      supportTaiList:
+        - plmnId:
+            mcc: 208
+            mnc: 93
+          tac: 1
+      plmnSupportList:
+        - plmnId:
+            mcc: 208
+            mnc: 93
+          snssaiList:
+            - sst: 1
+              sd: 010203
+            - sst: 1
+              sd: 112233
+      supportDnnList:
+        - internet
+      security:
+        integrityOrder:
+          - NIA2
+        cipheringOrder:
+          - NEA0
+      networkName:
+        full: free5GC
+        short: free      
+      locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
+      networkFeatureSupport5GS: # 5gs Network Feature Support IE, refer to TS 24.501
+        enable: true # append this IE in Registration accept or not
+        length: 1 # IE content length (uinteger, range: 1~3)
+        imsVoPS: 0 # IMS voice over PS session indicator (uinteger, range: 0~1)
+        emc: 0 # Emergency service support indicator for 3GPP access (uinteger, range: 0~3)
+        emf: 0 # Emergency service fallback indicator for 3GPP access (uinteger, range: 0~3)
+        iwkN26: 0 # Interworking without N26 interface indicator (uinteger, range: 0~1)
+        mpsi: 0 # MPS indicator (uinteger, range: 0~1)
+        emcN3: 0 # Emergency service support indicator for Non-3GPP access (uinteger, range: 0~1)
+        mcsi: 0 # MCS indicator (uinteger, range: 0~1)
+      t3502Value: 720
+      t3512Value: 3600
+      non3gppDeregistrationTimerValue: 3240
+      # retransmission timer for paging message
+      t3513:
+        enable: true     # true or false
+        expireTime: 6s   # default is 6 seconds
+        maxRetryTimes: 4 # the max number of retransmission
+      # retransmission timer for NAS Registration Accept message
+      t3522:
+        enable: true     # true or false
+        expireTime: 6s   # default is 6 seconds
+        maxRetryTimes: 4 # the max number of retransmission
+      # retransmission timer for NAS Registration Accept message
+      t3550:
+        enable: true     # true or false
+        expireTime: 6s   # default is 6 seconds
+        maxRetryTimes: 4 # the max number of retransmission
+      # retransmission timer for NAS Authentication Request/Security Mode Command message
+      t3560:
+        enable: true     # true or false
+        expireTime: 6s   # default is 6 seconds
+        maxRetryTimes: 4 # the max number of retransmission
+      # retransmission timer for NAS Notification message
+      t3565:
+        enable: true     # true or false
+        expireTime: 6s   # default is 6 seconds
+        maxRetryTimes: 4 # the max number of retransmission
+      t3570:
+        enable: true     # true or false
+        expireTime: 6s   # default is 6 seconds
+        maxRetryTimes: 4 # the max number of retransmission
+
+    logger:
+      AMF:
+        ReportCaller: false
+        debugLevel: info
+      Aper:
+        ReportCaller: false
+        debugLevel: info
+      FSM:
+        ReportCaller: false
+        debugLevel: info
+      NAS:
+        ReportCaller: false
+        debugLevel: info
+      NGAP:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/amf/amf-deployment.yaml
+++ b/free5gc-cp/amf/amf-deployment.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-amf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: amf
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: amf
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: '[
+            {
+              "name": "n2network-amf",
+              "interface": "n2",
+              "ips": [ "10.100.50.249/29" ],
+              "gateway": [ "10.100.50.254" ]
+            }
+            ]'
+      labels:
+        project: free5gc
+        nf: amf
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']   
+      
+      containers:
+      - name: amf
+        image: towards5gs/free5gc-amf:v3.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: namf
+          containerPort: 80
+        - name: n2
+          containerPort: 38412
+          protocol: SCTP
+        command: ["./amf"]
+        args: ["-c", "../config/amfcfg.yaml"]
+        env:
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: amf-volume
+        resources:
+            limits:
+              cpu: 150m
+              memory: 128Mi
+            requests:
+              cpu: 150m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: amf-volume
+        projected:
+          sources:
+          - configMap:
+              name: amf-configmap

--- a/free5gc-cp/amf/amf-networkattachmentdefinition.yaml
+++ b/free5gc-cp/amf/amf-networkattachmentdefinition.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: n2network-amf
+  namespace: default
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  config: '{
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "capabilities": { "ips": true },
+          "master": "ens3",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static",
+            "routes": [
+              {
+                "dst": "0.0.0.0/0",
+                "gw": "10.100.50.254"
+              }
+            ] 
+          }
+        }, {
+          "capabilities": { "mac": true },
+          "type": "tuning"
+        }
+      ]
+    }'

--- a/free5gc-cp/amf/amf-service.yaml
+++ b/free5gc-cp/amf/amf-service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: amf-namf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: amf
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: amf

--- a/free5gc-cp/ausf/ausf-configmap.yaml
+++ b/free5gc-cp/ausf/ausf-configmap.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ausf-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  ausfcfg.yaml: |
+    info:
+      version: 1.0.2
+      description: AUSF initial local configuration
+
+    configuration:
+      serviceNameList:
+        - nausf-auth
+      
+      sbi:
+        scheme: http
+        registerIPv4: ausf-nausf  # IP used to register to NRF
+        bindingIPv4: 0.0.0.0      # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/ausf.key
+          pem: config/TLS/ausf.pem
+      
+      nrfUri: http://nrf-nnrf:8000
+      plmnSupportList:
+        - mcc: 208
+          mnc: 93
+        - mcc: 123
+          mnc: 45
+      groupId: ausfGroup001
+      eapAkaSupiImsiPrefix: false
+
+    logger:
+      AUSF:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/ausf/ausf-deployment.yaml
+++ b/free5gc-cp/ausf/ausf-deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-ausf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: ausf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: ausf
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: ausf
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+      
+      containers:
+      - name: ausf
+        image: towards5gs/free5gc-ausf:v3.1.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            {}
+        ports:
+        - containerPort: 80
+        command: ["./ausf"]
+        args: ["-c", "../config/ausfcfg.yaml"]
+        env:
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: ausf-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: ausf-volume
+        projected:
+          sources:
+          - configMap:
+              name: ausf-configmap

--- a/free5gc-cp/ausf/ausf-service.yaml
+++ b/free5gc-cp/ausf/ausf-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ausf-nausf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: ausf
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: ausf

--- a/free5gc-cp/mongodb/dep-sts.yaml
+++ b/free5gc-cp/mongodb/dep-sts.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: default
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/instance: free5gc
+    app.kubernetes.io/component: mongodb
+spec:
+  serviceName: mongodb
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb
+      app.kubernetes.io/instance: free5gc
+      app.kubernetes.io/component: mongodb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mongodb
+        app.kubernetes.io/instance: free5gc
+        app.kubernetes.io/component: mongodb
+    spec:
+      
+      serviceAccountName: mongodb
+      affinity:
+        podAffinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: mongodb
+                    app.kubernetes.io/instance: free5gc
+                    app.kubernetes.io/component: mongodb
+                namespaces:
+                  - "default"
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        sysctls: []
+      containers:
+        - name: mongodb
+          image: docker.io/bitnami/mongodb:4.4.4-debian-10-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "yes"
+            - name: MONGODB_SYSTEM_LOG_VERBOSITY
+              value: "0"
+            - name: MONGODB_DISABLE_SYSTEM_LOG
+              value: "no"
+            - name: MONGODB_ENABLE_IPV6
+              value: "no"
+            - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+              value: "no"
+          ports:
+            - name: mongodb
+              containerPort: 27017
+          livenessProbe:
+            exec:
+              command:
+                - mongo
+                - --disableImplicitSessions
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - -ec
+                - |
+                  mongo --disableImplicitSessions $TLS_OPTIONS --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - name: datadir
+              mountPath: /bitnami/mongodb/data/db/
+              subPath: 
+      volumes:
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "6Gi"

--- a/free5gc-cp/mongodb/serviceaccount.yaml
+++ b/free5gc-cp/mongodb/serviceaccount.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mongodb
+  namespace: default
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/instance: free5gc
+secrets:
+  - name: mongodb

--- a/free5gc-cp/mongodb/svc.yaml
+++ b/free5gc-cp/mongodb/svc.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: default
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/instance: free5gc
+    app.kubernetes.io/component: mongodb
+spec:
+  type: ClusterIP
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: mongodb
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/instance: free5gc
+    app.kubernetes.io/component: mongodb

--- a/free5gc-cp/namespace.yaml
+++ b/free5gc-cp/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/free5gc-cp/nrf/nrf-configmap.yaml
+++ b/free5gc-cp/nrf/nrf-configmap.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nrf-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  nrfcfg.yaml: |
+    info:
+      version: 1.0.1
+      description: NRF initial local configuration
+    
+    configuration:
+      MongoDBName: free5gc
+      MongoDBUrl: mongodb://mongodb:27017
+
+      serviceNameList:
+        - nnrf-nfm
+        - nnrf-disc
+
+      sbi:
+        scheme: http
+        registerIPv4: nrf-nnrf  # IP used to serve NFs or register to another NRF
+        bindingIPv4: 0.0.0.0    # IP used to bind the service
+        port: 8000
+        tls:
+          key: config/TLS/nrf.key
+          pem: config/TLS/nrf.pem
+      DefaultPlmnId:
+        mcc: 208
+        mnc: 93
+
+    logger:
+      NRF:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/nrf/nrf-deployment.yaml
+++ b/free5gc-cp/nrf/nrf-deployment.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-nrf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: nrf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: nrf
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: nrf
+    spec:
+      initContainers:
+      - name: wait-mongo
+        image: busybox:1.32.0
+        env:
+        - name: DEPENDENCIES
+          value: mongodb:27017
+        command: ["sh", "-c", "until nc -z $DEPENDENCIES; do echo waiting for the MongoDB; sleep 2; done;"]
+      containers:
+      - name: nrf
+        image: towards5gs/free5gc-nrf:v3.1.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            {}
+        ports:
+        - containerPort: 8000
+        command: ["./nrf"]
+        args: ["-c", "../config/nrfcfg.yaml"]
+        env: 
+          - name: DB_URI
+            value: mongodb://mongodb/free5gc
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: nrf-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          timeoutSeconds: 1
+          failureThreshold:  40
+          successThreshold: 1
+          httpGet:
+            scheme: "HTTP"
+            port: 8000
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+          httpGet:
+            scheme: "HTTP"
+            port: 8000
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: nrf-volume
+        projected:
+          sources:
+          - configMap:
+              name: nrf-configmap

--- a/free5gc-cp/nrf/nrf-service.yaml
+++ b/free5gc-cp/nrf/nrf-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nrf-nnrf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: nrf
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: nrf

--- a/free5gc-cp/nssf/nssf-configmap.yaml
+++ b/free5gc-cp/nssf/nssf-configmap.yaml
@@ -1,0 +1,343 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nssf-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  nssfcfg.yaml: |
+    info:
+      version: 1.0.1
+      description: NSSF initial local configuration
+
+    configuration:
+      serviceNameList:
+        - nnssf-nsselection
+        - nnssf-nssaiavailability
+
+      sbi:
+        scheme: http
+        registerIPv4: nssf-nnssf  # IP used to register to NRF
+        bindingIPv4: 0.0.0.0      # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/nssf.key
+          pem: config/TLS/nssf.pem
+      
+      nrfUri: http://nrf-nnrf:8000
+      
+      nsiList:
+        - snssai:
+            sst: 1
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 10
+        - snssai:
+            sst: 1
+            sd: 1
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 11
+        - snssai:
+            sst: 1
+            sd: 2
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 12
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 12
+        - snssai:
+            sst: 1
+            sd: 3
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 13
+        - snssai:
+            sst: 2
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 20
+        - snssai:
+            sst: 2
+            sd: 1
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 21
+        - snssai:
+            sst: 1
+            sd: 010203
+          nsiInformationList:
+            - nrfId: http://nrf-nnrf:8000/nnrf-nfm/v1/nf-instances
+              nsiId: 22
+      amfSetList:
+        - amfSetId: 1
+          amfList:
+            - ffa2e8d7-3275-49c7-8631-6af1df1d9d26
+            - 0e8831c3-6286-4689-ab27-1e2161e15cb1
+            - a1fba9ba-2e39-4e22-9c74-f749da571d0d
+          nrfAmfSet: http://nrf-nnrf:8081/nnrf-nfm/v1/nf-instances
+          supportedNssaiAvailabilityData:
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33456
+              supportedSnssaiList:
+                - sst: 1
+                  sd: 1
+                - sst: 1
+                  sd: 2
+                - sst: 2
+                  sd: 1
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33457
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 1
+                  sd: 2
+        - amfSetId: 2
+          nrfAmfSet: http://nrf-nnrf:8084/nnrf-nfm/v1/nf-instances
+          supportedNssaiAvailabilityData:
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33456
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 1
+                  sd: 3
+                - sst: 2
+                  sd: 1
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33458
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 2
+      nssfName: NSSF
+      supportedPlmnList:
+        - mcc: 208
+          mnc: 93
+      supportedNssaiInPlmnList:
+        - plmnId:
+            mcc: 208
+            mnc: 93
+          supportedSnssaiList:
+            - sst: 1
+              sd: 010203
+            - sst: 1
+              sd: 112233
+            - sst: 1
+              sd: 3
+            - sst: 2
+              sd: 1
+            - sst: 2
+              sd: 2
+      amfList:
+        - nfId: 469de254-2fe5-4ca0-8381-af3f500af77c
+          supportedNssaiAvailabilityData:
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33456
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 2
+                - sst: 2
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33457
+              supportedSnssaiList:
+                - sst: 1
+                  sd: 1
+                - sst: 1
+                  sd: 2
+        - nfId: fbe604a8-27b2-417e-bd7c-8a7be2691f8d
+          supportedNssaiAvailabilityData:
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33458
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 1
+                  sd: 3
+                - sst: 2
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33459
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 2
+                - sst: 2
+                  sd: 1
+        - nfId: b9e6e2cb-5ce8-4cb6-9173-a266dd9a2f0c
+          supportedNssaiAvailabilityData:
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33456
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 1
+                  sd: 2
+                - sst: 2
+            - tai:
+                plmnId:
+                  mcc: 466
+                  mnc: 92
+                tac: 33458
+              supportedSnssaiList:
+                - sst: 1
+                - sst: 1
+                  sd: 1
+                - sst: 2
+                - sst: 2
+                  sd: 1
+      taList:
+        - tai:
+            plmnId:
+              mcc: 466
+              mnc: 92
+            tac: 33456
+          accessType: 3GPP_ACCESS
+          supportedSnssaiList:
+            - sst: 1
+            - sst: 1
+              sd: 1
+            - sst: 1
+              sd: 2
+            - sst: 2
+        - tai:
+            plmnId:
+              mcc: 466
+              mnc: 92
+            tac: 33457
+          accessType: 3GPP_ACCESS
+          supportedSnssaiList:
+            - sst: 1
+            - sst: 1
+              sd: 1
+            - sst: 1
+              sd: 2
+            - sst: 2
+        - tai:
+            plmnId:
+              mcc: 466
+              mnc: 92
+            tac: 33458
+          accessType: 3GPP_ACCESS
+          supportedSnssaiList:
+            - sst: 1
+            - sst: 1
+              sd: 1
+            - sst: 1
+              sd: 3
+            - sst: 2
+          restrictedSnssaiList:
+            - homePlmnId:
+                mcc: 310
+                mnc: 560
+              sNssaiList:
+                - sst: 1
+                  sd: 3
+        - tai:
+            plmnId:
+              mcc: 466
+              mnc: 92
+            tac: 33459
+          accessType: 3GPP_ACCESS
+          supportedSnssaiList:
+            - sst: 1
+            - sst: 1
+              sd: 1
+            - sst: 2
+            - sst: 2
+              sd: 1
+          restrictedSnssaiList:
+            - homePlmnId:
+                mcc: 310
+                mnc: 560
+              sNssaiList:
+                - sst: 2
+                  sd: 1
+      mappingListFromPlmn:
+        - operatorName: NTT Docomo
+          homePlmnId:
+            mcc: 440
+            mnc: 10
+          mappingOfSnssai:
+            - servingSnssai:
+                sst: 1
+                sd: 1
+              homeSnssai:
+                sst: 1
+                sd: 1
+            - servingSnssai:
+                sst: 1
+                sd: 2
+              homeSnssai:
+                sst: 1
+                sd: 3
+            - servingSnssai:
+                sst: 1
+                sd: 3
+              homeSnssai:
+                sst: 1
+                sd: 4
+            - servingSnssai:
+                sst: 2
+                sd: 1
+              homeSnssai:
+                sst: 2
+                sd: 2
+        - operatorName: AT&T Mobility
+          homePlmnId:
+            mcc: 310
+            mnc: 560
+          mappingOfSnssai:
+            - servingSnssai:
+                sst: 1
+                sd: 1
+              homeSnssai:
+                sst: 1
+                sd: 2
+            - servingSnssai:
+                sst: 1
+                sd: 2
+              homeSnssai:
+                sst: 1
+                sd: 3      
+
+    logger:
+      NSSF:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/nssf/nssf-deployment.yaml
+++ b/free5gc-cp/nssf/nssf-deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-nssf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: nssf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: nssf
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: nssf
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+
+      containers:
+      - name: nssf
+        image: towards5gs/free5gc-nssf:v3.1.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            {}
+        ports:
+        - containerPort: 80
+        command: ["./nssf"]
+        args: ["-c", "../config/nssfcfg.yaml"]
+        env: 
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: nssf-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: nssf-volume
+        projected:
+          sources:
+          - configMap:
+              name: nssf-configmap

--- a/free5gc-cp/nssf/nssf-service.yaml
+++ b/free5gc-cp/nssf/nssf-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nssf-nnssf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: nssf
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: nssf

--- a/free5gc-cp/package-context.yaml
+++ b/free5gc-cp/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: free5gc
+  namespace: free5gc

--- a/free5gc-cp/pcf/pcf-configmap.yaml
+++ b/free5gc-cp/pcf/pcf-configmap.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pcf-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  pcfcfg.yaml: |
+    info:
+      version: 1.0.1
+      description: PCF initial local configuration
+
+    configuration:
+      serviceList:
+        - serviceName: npcf-am-policy-control
+        - serviceName: npcf-smpolicycontrol
+          suppFeat: 3fff
+        - serviceName: npcf-bdtpolicycontrol
+        - serviceName: npcf-policyauthorization
+          suppFeat: 3
+        - serviceName: npcf-eventexposure
+        - serviceName: npcf-ue-policy-control
+
+      sbi:
+        scheme: http
+        registerIPv4: pcf-npcf  # IP used to register to NRF
+        bindingIPv4: 0.0.0.0    # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/pcf.key
+          pem: config/TLS/pcf.pem
+      
+      mongodb:       # the mongodb connected by this PCF
+        name: free5gc                  # name of the mongodb
+        url: mongodb://mongodb:27017 # a valid URL of the mongodb
+      
+      nrfUri: http://nrf-nnrf:8000
+      pcfName: PCF
+      timeFormat: 2019-01-02 15:04:05
+      defaultBdtRefId: BdtPolicyId-
+      locality: area1
+
+    logger:
+      PCF:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/pcf/pcf-deployment.yaml
+++ b/free5gc-cp/pcf/pcf-deployment.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-pcf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: pcf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: pcf
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: pcf
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+
+      containers:
+      - name: pcf
+        image: towards5gs/free5gc-pcf:v3.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        command: ["./pcf"]
+        args: ["-c", "../config/pcfcfg.yaml"]
+        env:
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: pcf-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: pcf-volume
+        projected:
+          sources:
+          - configMap:
+              name: pcf-configmap

--- a/free5gc-cp/pcf/pcf-service.yaml
+++ b/free5gc-cp/pcf/pcf-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pcf-npcf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: pcf
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: pcf

--- a/free5gc-cp/smf/smf-configmap.yaml
+++ b/free5gc-cp/smf/smf-configmap.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smf-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  smfcfg.yaml: |
+    info:
+      version: 1.0.2
+      description: SMF initial local configuration
+
+    configuration:
+      serviceNameList:
+        - nsmf-pdusession
+        - nsmf-event-exposure
+        - nsmf-oam
+      
+      sbi:
+        scheme: http
+        registerIPv4: smf-nsmf # IP used to register to NRF
+        bindingIPv4: 0.0.0.0  # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/smf.key
+          pem: config/TLS/smf.pem
+      
+      nrfUri: http://nrf-nnrf:8000
+
+      pfcp:
+        addr: 192.168.1.10
+      smfName: SMF
+      snssaiInfos:
+        - sNssai:
+            sst: 1
+            sd: 010203
+          dnnInfos: # DNN information list
+            - dnn: internet # Data Network Name
+              dns: # the IP address of DNS
+                ipv4: 8.8.8.8
+        - sNssai:
+            sst: 1
+            sd: 112233
+          dnnInfos: # DNN information list
+            - dnn: internet # Data Network Name
+              dns: # the IP address of DNS
+                ipv4: 8.8.8.8
+        - sNssai:
+            sst: 2
+            sd: 112234    
+          dnnInfos:
+            - dnn: internet
+              dns: 
+                ipv4: 8.8.8.8
+      plmnList: # the list of PLMN IDs that this SMF belongs to (optional, remove this key when unnecessary)
+        - mcc: "208" # Mobile Country Code (3 digits string, digit: 0~9)
+          mnc: "93" # Mobile Network Code (2 or 3 digits string, digit: 0~9)
+      userplaneInformation: # list of userplane information
+        upNodes: # information of userplane node (AN or UPF)
+          gNB1: # the name of the node
+            type: AN # the type of the node (AN or UPF)
+          UPF:  # the name of the node
+            type: UPF # the type of the node (AN or UPF)
+            nodeID: 192.168.1.2 # the IP/FQDN of N4 interface on this UPF (PFCP)
+            sNssaiUpfInfos: # S-NSSAI information list for this UPF
+                  - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+                      sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+                      sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+                    dnnUpfInfoList: # DNN information list for this S-NSSAI
+                      - dnn: internet
+                        pools:
+                          - cidr: 10.1.0.0/16
+            interfaces: # Interface list for this UPF
+                  - interfaceType: N3 # the type of the interface (N3 or N9)
+                    endpoints: # the IP address of this N3/N9 interface on this UPF
+                      - 10.0.0.2
+                    networkInstance: internet # Data Network Name (DNN)
+        links: # the topology graph of userplane, A and B represent the two nodes of each link
+          - A: gNB1
+            B: UPF
+      locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
+
+    logger:
+      Aper:
+        ReportCaller: false
+        debugLevel: info
+      NAS:
+        ReportCaller: false
+        debugLevel: info
+      NGAP:
+        ReportCaller: false
+        debugLevel: info
+      PFCP:
+        ReportCaller: false
+        debugLevel: info
+      SMF:
+        ReportCaller: false
+        debugLevel: info
+
+
+  uerouting.yaml: |
+    info:
+      version: 1.0.1
+      description: Routing information for UE
+    ueRoutingInfo:
+      UE1: # Group Name
+        members:
+        - imsi-208930000000003 # Subscription Permanent Identifier of the UE
+        topology: # Network topology for this group (Uplink: A->B, Downlink: B->A)
+        # default path derived from this topology
+        # node name should be consistent with smfcfg.yaml
+          - A: gNB1
+            B: UPF

--- a/free5gc-cp/smf/smf-deployment.yaml
+++ b/free5gc-cp/smf/smf-deployment.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-smf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: smf
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: smf
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: '[
+            { 
+              "name": "n4network-smf",
+              "interface": "n4",
+              "ips": [ "192.168.1.10/24" ],
+              "gateway": [ "192.168.1.1" ]
+            }]'
+      labels:
+        project: free5gc
+        nf: smf
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+
+      containers:
+      - name: smf
+        image: towards5gs/free5gc-smf:v3.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: nsmf
+          containerPort: 80
+        - name: n4
+          containerPort: 8805
+          protocol: UDP
+        command: ["./smf"]
+        args: ["-c", "../config/smfcfg.yaml", "-u", "../config/uerouting.yaml"]
+        env:
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: smf-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: smf-volume
+        projected:
+          sources:
+          - configMap:
+              name: smf-configmap
+              items:
+              - key: smfcfg.yaml
+                path: smfcfg.yaml
+              - key: uerouting.yaml
+                path: uerouting.yaml

--- a/free5gc-cp/smf/smf-networkattachmentdefinition.yaml
+++ b/free5gc-cp/smf/smf-networkattachmentdefinition.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: n4network-smf
+  namespace: default
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  config: '{
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "capabilities": { "ips": true },
+          "master": "ens3",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static",
+            "routes": [
+              {
+                "dst": "0.0.0.0/0",
+                "gw": "192.168.1.1"
+              }
+            ] 
+          }
+        }, {
+          "capabilities": { "mac": true },
+          "type": "tuning"
+        }
+      ]
+    }'

--- a/free5gc-cp/smf/smf-service.yaml
+++ b/free5gc-cp/smf/smf-service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smf-nsmf
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: smf
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: smf

--- a/free5gc-cp/udm/udm-configmap.yaml
+++ b/free5gc-cp/udm/udm-configmap.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: udm-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  udmcfg.yaml: |
+    info:
+      version: 1.0.2
+      description: UDM initial local configuration
+
+    configuration:
+      serviceNameList:
+        - nudm-sdm
+        - nudm-uecm
+        - nudm-ueau
+        - nudm-ee
+        - nudm-pp
+      
+      sbi:
+        scheme: http
+        registerIPv4: udm-nudm # IP used to register to NRF
+        bindingIPv4: 0.0.0.0  # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/udm.key
+          pem: config/TLS/udm.pem
+      
+      nrfUri: http://nrf-nnrf:8000
+      # test data set from TS33501-f60 Annex C.4
+      SuciProfile:
+        - ProtectionScheme: 1 # Protect Scheme: Profile A
+          PrivateKey: c53c22208b61860b06c62e5406a7b330c2b577aa5558981510d128247d38bd1d
+          PublicKey: 5a8d38864820197c3394b92613b20b91633cbd897119273bf8e4a6f4eec0a650
+        - ProtectionScheme: 2 # Protect Scheme: Profile B
+          PrivateKey: F1AB1074477EBCC7F554EA1C5FC368B1616730155E0041AC447D6301975FECDA
+          PublicKey: 0472DA71976234CE833A6907425867B82E074D44EF907DFB4B3E21C1C2256EBCD15A7DED52FCBB097A4ED250E036C7B9C8C7004C4EEDC4F068CD7BF8D3F900E3B4
+
+    logger:
+      UDM:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/udm/udm-deployment.yaml
+++ b/free5gc-cp/udm/udm-deployment.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-udm
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: udm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: udm
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: udm
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+
+      containers:
+      - name: udm
+        image: towards5gs/free5gc-udm:v3.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        command: ["./udm"]
+        args: ["-c", "../config/udmcfg.yaml"]
+        env: 
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: udm-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: udm-volume
+        projected:
+          sources:
+          - configMap:
+              name: udm-configmap

--- a/free5gc-cp/udm/udm-service.yaml
+++ b/free5gc-cp/udm/udm-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udm-nudm
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: udm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: udm

--- a/free5gc-cp/udr/udr-configmap.yaml
+++ b/free5gc-cp/udr/udr-configmap.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: udr-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  udrcfg.yaml: |
+    info:
+      version: 1.0.1
+      description: UDR initial local configuration
+
+    configuration:
+      sbi:
+        scheme: http
+        registerIPv4: udr-nudr # IP used to register to NRF
+        bindingIPv4: 0.0.0.0  # IP used to bind the service
+        port: 80
+        tls:
+          key: config/TLS/udr.key
+          pem: config/TLS/udr.pem
+
+      mongodb:
+        name: free5gc
+        url: mongodb://mongodb:27017       
+      
+      nrfUri: http://nrf-nnrf:8000
+
+    logger:
+      MongoDBLibrary:
+        ReportCaller: false
+        debugLevel: info
+      OpenApi:
+        ReportCaller: false
+        debugLevel: info
+      PathUtil:
+        ReportCaller: false
+        debugLevel: info
+      UDR:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/udr/udr-deployment.yaml
+++ b/free5gc-cp/udr/udr-deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-udr
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: udr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: udr
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: udr
+    spec:
+      initContainers:
+      - name: wait-nrf
+        image: towards5gs/initcurl:1.0.0
+        env:
+        - name: DEPENDENCIES
+          value: http://nrf-nnrf:8000
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+
+      containers:
+      - name: udr
+        image: towards5gs/free5gc-udr:v3.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        command: ["./udr"]
+        args: ["-c", "../config/udrcfg.yaml"]
+        env: 
+          - name: DB_URI
+            value: mongodb://mongodb/free5gc
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: udr-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: udr-volume
+        projected:
+          sources:
+          - configMap:
+              name: udr-configmap

--- a/free5gc-cp/udr/udr-service.yaml
+++ b/free5gc-cp/udr/udr-service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udr-nudr
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: udr
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: udr

--- a/free5gc-cp/webui/webui-configmap.yaml
+++ b/free5gc-cp/webui/webui-configmap.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webui-configmap
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    app: free5gc
+data:
+  webuicfg.yaml: |
+    info:
+      version: 1.0.0
+      description: WEBUI initial local configuration
+
+    configuration:
+      mongodb:
+        name: free5gc
+        url: mongodb://mongodb:27017
+        
+    logger:
+      WEBUI:
+        ReportCaller: false
+        debugLevel: info

--- a/free5gc-cp/webui/webui-deployment.yaml
+++ b/free5gc-cp/webui/webui-deployment.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: free5gc-webui
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      project: free5gc
+      nf: webui
+  template:
+    metadata:
+      labels:
+        project: free5gc
+        nf: webui
+    spec:
+      initContainers:
+      - name: wait-mongo
+        image: busybox:1.32.0
+        env:
+        - name: DEPENDENCIES
+          value: mongodb:27017
+        command: ["sh", "-c", "until nc -z $DEPENDENCIES; do echo waiting for the MongoDB; sleep 2; done;"]
+      containers:
+      - name: webui
+        image: towards5gs/free5gc-webui:v3.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5000
+        command: ["./webconsole"]
+        args: ["-c", "../config/webuicfg.yaml"]
+        env:
+          - name: GIN_MODE
+            value: release
+        volumeMounts:
+        - mountPath: /free5gc/config/
+          name: webui-volume
+        resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          timeoutSeconds: 1
+          failureThreshold:  40
+          successThreshold: 1
+          httpGet:
+            scheme: HTTP
+            port: 5000
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+          httpGet:
+            scheme: HTTP
+            port: 5000
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: webui-volume
+        projected:
+          sources:
+          - configMap:
+              name: webui-configmap

--- a/free5gc-cp/webui/webui-service.yaml
+++ b/free5gc-cp/webui/webui-service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webui-service
+  labels:
+    app.kubernetes.io/version: "v3.1.1"
+    project: free5gc
+    nf: webui
+spec:
+  type: NodePort
+  ports:
+    - port: 5000
+      targetPort: 5000
+      nodePort: 30500
+      protocol: TCP
+      name: http
+  selector:
+    project: free5gc
+    nf: webui


### PR DESCRIPTION
Initial implementation of free5gc-cp kpt package based on [Towards5gs helm charts](https://github.com/Orange-OpenSource/towards5gs-helm), as discussed in [nephio-project/nephio#105](https://github.com/nephio-project/nephio/issues/105)

AMF and SMF will be deployed via specialization pipeline, but I marked these with **local-config** and left for the reference (it won't be deployed to the cluster).

All service-level configuration stays as default Towards5gs configuration.

**Dependencies:**
   - mongodb requires PV. **Action point:** we need to assure that dynamic PV provisioning will be available on teh cluster
   - both AMF and SMF should include **_wait-nrf_** init-container (other functions as well, but it's done)
   - NRF and WEBUI should include **_wait-mongodb_** init-container (it's done)
   - webui will be accessible via NodePort to register UE on the free5gc side
