### PR TITLE
Fix mismatch between selector and deployment labels

### DIFF
--- a/free5gc-operator/operator/clusterrole.yaml
+++ b/free5gc-operator/operator/clusterrole.yaml
@@ -3,13 +3,6 @@ kind: ClusterRole
 
 metadata:
   name: free5gc-operator-role
-  labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: free5gc-operator-role
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator
-
 rules:
 - apiGroups:
   - ""

--- a/free5gc-operator/operator/clusterrolebinding.yaml
+++ b/free5gc-operator/operator/clusterrolebinding.yaml
@@ -3,13 +3,6 @@ kind: ClusterRoleBinding
 
 metadata:
   name: free5gc-operator-role-binding
-  labels:
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: free5gc-operator-role-binding
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator
-
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/free5gc-operator/operator/deployment.yaml
+++ b/free5gc-operator/operator/deployment.yaml
@@ -1,30 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
-
 metadata:
   namespace: free5gc
   name: free5gc-operator
-  labels:
-    app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: free5gc-operator
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator
-
 spec:
   replicas: 1
   selector:
     matchLabels:
-      fn.kptgen.dev/controller: free5gc-operator
+      app.kubernetes.io/name: free5gc-operator
+      app.kubernetes.io/component: controller
   template:
     metadata:
       name: free5gc-operator
       labels:
-        app.kubernetes.io/name: deployment
-        app.kubernetes.io/instance: free5gc-operator
-        app.kubernetes.io/component: operator
-        app.kubernetes.io/created-by: nephio
-        app.kubernetes.io/part-of: free5gc-operator
+        app.kubernetes.io/name: free5gc-operator
+        app.kubernetes.io/component: controller
     spec:
       serviceAccountName: free5gc-operator
       containers:

--- a/free5gc-operator/operator/namespace.yaml
+++ b/free5gc-operator/operator/namespace.yaml
@@ -1,11 +1,4 @@
 apiVersion: v1
 kind: Namespace
-
 metadata:
   name: free5gc
-  labels:
-    app.kubernetes.io/name: namespace
-    app.kubernetes.io/instance: free5gc
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator

--- a/free5gc-operator/operator/role-leader-election.yaml
+++ b/free5gc-operator/operator/role-leader-election.yaml
@@ -1,16 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-
 metadata:
   namespace: free5gc
   name: free5gc-operator-leader-election-role
-  labels:
-    app.kubernetes.io/name: role
-    app.kubernetes.io/instance: free5gc-operator-leader-election-role
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator
-
 rules:
 - apiGroups:
   - ""

--- a/free5gc-operator/operator/rolebinding-leader-election.yaml
+++ b/free5gc-operator/operator/rolebinding-leader-election.yaml
@@ -1,16 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-
 metadata:
   namespace: free5gc
   name: free5gc-operator-leader-election-role-binding
-  labels:
-    app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: free5gc-operator-leader-election-role-binding
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator
-
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/free5gc-operator/operator/serviceaccount.yaml
+++ b/free5gc-operator/operator/serviceaccount.yaml
@@ -1,12 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
-
 metadata:
   namespace: free5gc
   name: free5gc-operator
-  labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: free5gc-operator
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/created-by: nephio
-    app.kubernetes.io/part-of: free5gc-operator

--- a/free5gc-operator/package-context.yaml
+++ b/free5gc-operator/package-context.yaml
@@ -7,4 +7,4 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 data:
-  name: nehpio
+  name: example


### PR DESCRIPTION
The operator wouldn't deploy, because the label selector and template labels did not match.

I also removed the use of a bunch of K8s standard labels that were not being correctly used.