### PR TITLE
Updated free5gc smf package to align with r2

### DIFF
--- a/pkg-example-smf-bp/Kptfile
+++ b/pkg-example-smf-bp/Kptfile
@@ -14,10 +14,10 @@ pipeline:
       configPath: apply-replacements-namespace.yaml
     - image: gcr.io/kpt-fn/set-namespace:v0.4.1
       configPath: cm-namespace.yaml
-    - image: docker.io/nephio/smf-deploy-fn:v1.0.1
+    - image: nephio/nfdeploy-fn:1729579664202010624
     - image: docker.io/nephio/interface-fn:v1.0.1
     - image: docker.io/nephio/dnn-fn:v1.0.1
     - image: docker.io/nephio/nad-fn:v1.0.1
     - image: docker.io/nephio/dnn-fn:v1.0.1
     - image: docker.io/nephio/interface-fn:v1.0.1
-    - image: docker.io/nephio/smf-deploy-fn:v1.0.1
+    - image: nephio/nfdeploy-fn:1729579664202010624

--- a/pkg-example-smf-bp/apply-replacements-owner.yaml
+++ b/pkg-example-smf-bp/apply-replacements-owner.yaml
@@ -11,7 +11,7 @@ replacements:
     fieldPath: spec.clusterName
   targets:
   - select:
-      kind: SMFDeployment
+      kind: NFDeployment
     fieldPaths:
     - metadata.name
     options:

--- a/pkg-example-smf-bp/capacity.yaml
+++ b/pkg-example-smf-bp/capacity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: control-plane
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:
   maxSessions: 500

--- a/pkg-example-smf-bp/dependency.yaml
+++ b/pkg-example-smf-bp/dependency.yaml
@@ -4,7 +4,7 @@ metadata:
   name: upf
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:
   packageName: free5gc-upf

--- a/pkg-example-smf-bp/dnn.yaml
+++ b/pkg-example-smf-bp/dnn.yaml
@@ -4,6 +4,6 @@ metadata:
   name: internet
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:

--- a/pkg-example-smf-bp/interface-n11.yaml
+++ b/pkg-example-smf-bp/interface-n11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: n11
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:
   networkInstance:

--- a/pkg-example-smf-bp/interface-n4.yaml
+++ b/pkg-example-smf-bp/interface-n4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: n4 # also used as pfcp
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:
   networkInstance:

--- a/pkg-example-smf-bp/interface-sba.yaml
+++ b/pkg-example-smf-bp/interface-sba.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sbi
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:
   networkInstance:

--- a/pkg-example-smf-bp/smfdeployment.yaml
+++ b/pkg-example-smf-bp/smfdeployment.yaml
@@ -1,5 +1,7 @@
 apiVersion: workload.nephio.org/v1alpha1
-kind: SMFDeployment
+kind: NFDeployment
 metadata:
   name: smf-example
   namespace: smf-example
+spec:
+  provider: smf.free5gc.io

--- a/pkg-example-upf-bp/interface-sba.yaml
+++ b/pkg-example-upf-bp/interface-sba.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sbi
   annotations:
     config.kubernetes.io/local-config: "true"
-    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.SMFDeployment.smf-example
+    specializer.nephio.org/owner: workload.nephio.org/v1alpha1.NFDeployment.smf-example
     specializer.nephio.org/namespace: example
 spec:
   networkInstance:


### PR DESCRIPTION
Updating packages to move into [catalog](https://github.com/nephio-project/catalog/tree/main/workloads/free5gc)

Based on [49](https://github.com/nephio-project/free5gc-packages/pull/49)